### PR TITLE
RetroArch ignores the core framerate by default, must use 60 for comp…

### DIFF
--- a/src/emulator.h
+++ b/src/emulator.h
@@ -108,7 +108,7 @@ typedef struct{
 }misc_hw_t;
 
 //config options
-#define EMU_FPS 30
+#define EMU_FPS 60
 #define EMU_SYSCLK_PRECISION 2000000//the amount of cycles to run before adding SYSCLKs, higher = faster, higher values may skip timer events and lower audio accuracy
 #define AUDIO_SAMPLE_RATE 48000
 #define AUDIO_CLOCK_RATE 235929600//smallest amount of time a second can be split into:(2.0 * (14.0 * (255 + 1.0) + 15 + 1.0)) * 32768 == 235929600, used to convert the variable timing of SYSCLK and CLK32 to a fixed location in the current frame 0<->AUDIO_END_OF_FRAME


### PR DESCRIPTION
…atiblity