### PR TITLE
Fix 4 bugs

### DIFF
--- a/libretroBuildSystem/build/Makefile.common
+++ b/libretroBuildSystem/build/Makefile.common
@@ -37,7 +37,7 @@ ifneq (,$(findstring windows,$(this_system)))
          EMU_ARCH := x86_32
       endif
    else
-      # MSVC uses its own(incompatible) syntax
+      # MSVC uses its own(incompatible) ASM syntax
       EMU_SUPPORT_PALM_OS5 := 0
    endif
 else ifneq (,$(filter %armv8% %aarch64% rpi3,$(this_system)))
@@ -52,6 +52,7 @@ else ifneq (,$(filter %armv% rpi2,$(this_system)))
    EMU_OS := linux
 else ifneq (,$(findstring armhf,$(this_system)))
    # ARM Linux ARMv5
+   # this needs to be before "linux%" because it will trigger the linux case
    EMU_SUPPORT_PALM_OS5 := 0
 else ifneq (,$(filter osx% linux% ,$(this_system)))
    # x86_* Linux
@@ -62,9 +63,6 @@ else ifneq (,$(filter osx% linux% ,$(this_system)))
       EMU_ARCH := x86_32
    endif
    EMU_OS := linux
-else
-   # Dont know, but cant run OS 5
-   EMU_SUPPORT_PALM_OS5 := 0
 endif
 
 # OS 5 isnt even booting yet, just turn the dynarec off to make it compile easier
@@ -78,14 +76,15 @@ else ifeq ($(this_system), osx)
 	endif
 endif
 
-# use all CPUs and optimize for the most likely outcome, android is handled separately
+# use all CPUs and optimize for the most likely outcome, Android is handled separately
 # Apple broke OpenMP in there port of Clang so no Mac OS or iOS
 ifneq (,$(filter %armv% windows% linux%,$(this_system)))
    ifeq (,$(findstring msvc,$(this_system)))
       COREDEFINES += -fopenmp -DEMU_MULTITHREADED -DEMU_MANAGE_HOST_CPU_PIPELINE
       LDFLAGS += -fopenmp
-   else
-      COREDEFINES += -openmp -D_Pragma=__pragma -DEMU_MULTITHREADED -DEMU_MANAGE_HOST_CPU_PIPELINE
+   else ifeq (,$(findstring msvc2003,$(this_system)))
+      #MSVC2003 dosent have OpenMP and all versions of MSVC lack __builtin_expect(x, y)
+      COREDEFINES += -openmp -D_Pragma=__pragma -DEMU_MULTITHREADED
       LDFLAGS += -openmp
    endif
 endif

--- a/libretroBuildSystem/libretro.c
+++ b/libretroBuildSystem/libretro.c
@@ -151,7 +151,7 @@ static void check_variables(bool booting){
       useJoystickAsMouse = !strcmp(var.value, "enabled");
    
 #if defined(EMU_SUPPORT_PALM_OS5)
-   var.key = "palm_emu_use_os_5";
+   var.key = "palm_emu_use_os5";
    if(environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       useOs5 = !strcmp(var.value, "enabled");
 #endif
@@ -215,7 +215,7 @@ void retro_set_environment(retro_environment_t cb){
       { "palm_emu_feature_durable", "Ignore Invalid Behavior; disabled|enabled" },
       { "palm_emu_use_joystick_as_mouse", "Use Left Joystick As Mouse; disabled|enabled" },
 #if defined(EMU_SUPPORT_PALM_OS5)
-      { "palm_emu_use_os_5", "Boot Apps In OS 5; disabled|enabled" },
+      { "palm_emu_use_os5", "Boot Apps In OS 5; disabled|enabled" },
 #endif
       { 0 }
    };
@@ -284,7 +284,7 @@ void retro_run(void){
    
 #if defined(EMU_SUPPORT_PALM_OS5)
    //some RetroArch functions can only be called from this function so call those if needed
-   if(firstRetroRunCall){
+   if(unlikely(firstRetroRunCall)){
       if(useOs5){
          struct retro_game_geometry geometry;
 

--- a/qtBuildSystem/Mu/Mu.pro
+++ b/qtBuildSystem/Mu/Mu.pro
@@ -29,19 +29,19 @@ windows{
     *msvc*{
         QMAKE_CFLAGS += -openmp
         QMAKE_CXXFLAGS += -openmp
-        DEFINES += "_Pragma=__pragma"
+        DEFINES += "_Pragma=__pragma" EMU_MULTITHREADED
     }
     *-g++{
         QMAKE_CFLAGS += -fopenmp
         QMAKE_CXXFLAGS += -fopenmp
         QMAKE_LFLAGS += -fopenmp
+        DEFINES += EMU_MULTITHREADED EMU_MANAGE_HOST_CPU_PIPELINE
     }
-    DEFINES += EMU_MULTITHREADED EMU_MANAGE_HOST_CPU_PIPELINE
     CONFIG += cpu_x86_32 # this should be auto detected in the future
 }
 
 macx{
-    QMAKE_CFLAGS += -std=c89 -D__STDBOOL_H -Dinline= -Dbool=char -Dtrue=1 -Dfalse=0 # tests C89 mode
+    # QMAKE_CFLAGS += -std=c89 -D__STDBOOL_H -Dinline= -Dbool=char -Dtrue=1 -Dfalse=0 # tests C89 mode
     ICON = macos/Mu.icns
     QMAKE_INFO_PLIST = macos/Info.plist
     DEFINES += EMU_MULTITHREADED EMU_MANAGE_HOST_CPU_PIPELINE

--- a/roadmap.txt
+++ b/roadmap.txt
@@ -20,6 +20,7 @@ RetroArch GUI:
 *allow mouse cursor to be rendered with multiple CPUs
 *now launches content like cartridge based systems
 //TODO: allow adding more content after boot
+//TODO: get EMU_MANAGE_HOST_CPU_PIPELINE working on other platforms then the main 4
 *booting without game works again
 *add multithreading and pipeline speedups
 

--- a/src/armv5te/cpu.cpp
+++ b/src/armv5te/cpu.cpp
@@ -1,12 +1,12 @@
 #include <algorithm>
-#include <cassert>
-#include <mutex>
+//#include <mutex>
+#include <assert.h>
 #include <setjmp.h>
 
 // Uncomment the following line to measure the time until the OS is loaded
 // #define BENCHMARK
 #ifdef BENCHMARK
-    #include <ctime>
+    #include <time.h>
 #endif
 
 #include "armsnippets.h"


### PR DESCRIPTION
Prevent the standard case from overwriting EMU_SUPPORT_PALM_OS5 := 1 from the jni makefile.
Remove unsupported __builtin_expect(x, y) from MSVC compilers.
Use <*.h> headers instead of <c*> headers for C headers in C++11 for RetroArchs weird Mac OS toolchain.
Remove unused <mutex> header for RetroArchs weird Mac OS toolchain.